### PR TITLE
Add keep-alive workflow for scheduled actions

### DIFF
--- a/.github/workflows/keepalive.yml
+++ b/.github/workflows/keepalive.yml
@@ -6,6 +6,10 @@ on:
     - cron: '0 0 1 * *'
   workflow_dispatch:
 
+concurrency:
+  group: keepalive
+  cancel-in-progress: true
+
 jobs:
   keepalive:
     runs-on: ubuntu-latest
@@ -13,6 +17,8 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: trunk
 
       - name: Update keepalive timestamp
         run: date -u '+%Y-%m-%dT%H:%M:%SZ' > .github/.keepalive

--- a/.github/workflows/keepalive.yml
+++ b/.github/workflows/keepalive.yml
@@ -1,0 +1,27 @@
+name: Keep workflows alive
+
+on:
+  schedule:
+    # Run on the 1st of every month at midnight UTC
+    - cron: '0 0 1 * *'
+  workflow_dispatch:
+
+jobs:
+  keepalive:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Update keepalive timestamp
+        run: date -u '+%Y-%m-%dT%H:%M:%SZ' > .github/.keepalive
+
+      - name: Commit and push if changed
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add .github/.keepalive
+          git diff --staged --quiet && echo "No changes" && exit 0
+          git commit -m "Update keepalive timestamp"
+          git push


### PR DESCRIPTION
## Summary
- Adds a monthly keep-alive workflow that writes a timestamp to `.github/.keepalive`
- This prevents GitHub from silently stopping scheduled workflow runs due to repository inactivity
- Fixes the label-notifier workflow which stopped running after no commits since December 2025

## How it works
GitHub deprioritizes and eventually disables scheduled workflows on repos with no recent commit activity. This workflow runs on the 1st of every month, commits a small timestamp file, and resets the inactivity clock for all workflows — including itself.

Can also be triggered manually via `workflow_dispatch` if needed.

Claude help with it. 