### PR TITLE
Fix follow-up reminder duplicate check

### DIFF
--- a/.github/workflows/label-notifier.yml
+++ b/.github/workflows/label-notifier.yml
@@ -82,7 +82,7 @@ jobs:
             }
             
             // Send the follow-up notification
-            const message = `📢 Reminder ${recipients} The publication deadline is approaching (5th of the month).`;
+            const message = `📢 20-Day Follow-up Reminder ${recipients} The publication deadline is approaching (5th of the month).`;
             
             await github.rest.issues.createComment({
               owner: context.repo.owner,


### PR DESCRIPTION
## Summary
- The duplicate check looks for `📢 20-Day Follow-up Reminder` in existing comments
- But the posted message started with `📢 Reminder` — so the check never matched its own comments
- Aligns the message text to include the marker string the dedup check expects

## Test plan
- [x] Verify the follow-up comment now contains `📢 20-Day Follow-up Reminder`
- [x] Verify a second run on the same day skips posting (dedup works)