### PR TITLE
Auto-create next Monthly Roundup issue on close

### DIFF
--- a/.github/workflows/create-roundup-issue.yml
+++ b/.github/workflows/create-roundup-issue.yml
@@ -59,3 +59,11 @@ jobs:
             });
 
             console.log(`✅ Created issue #${issue.data.number}: ${title}`);
+
+            // Notify editors to update Google Doc and author
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issue.data.number,
+              body: '@justintadlock @bph Please update the **Google Doc** link and assign an **Author** for this edition.'
+            });

--- a/.github/workflows/create-roundup-issue.yml
+++ b/.github/workflows/create-roundup-issue.yml
@@ -6,7 +6,10 @@ on:
 
 jobs:
   create-next-issue:
-    if: contains(github.event.issue.labels.*.name, 'Monthly Roundup')
+    if: >-
+      contains(github.event.issue.labels.*.name, 'Monthly Roundup') &&
+      github.event.sender.type != 'Bot' &&
+      github.event.issue.state_reason == 'completed'
     runs-on: ubuntu-latest
     permissions:
       issues: write

--- a/.github/workflows/create-roundup-issue.yml
+++ b/.github/workflows/create-roundup-issue.yml
@@ -63,6 +63,9 @@ jobs:
 
             console.log(`✅ Created issue #${issue.data.number}: ${title}`);
 
+            // Wait briefly for the issue to be fully available
+            await new Promise(resolve => setTimeout(resolve, 3000));
+
             // Notify editors to update Google Doc and author
             await github.rest.issues.createComment({
               owner: context.repo.owner,

--- a/.github/workflows/create-roundup-issue.yml
+++ b/.github/workflows/create-roundup-issue.yml
@@ -1,0 +1,61 @@
+name: Create next Monthly Roundup issue
+
+on:
+  issues:
+    types: [closed]
+
+jobs:
+  create-next-issue:
+    if: contains(github.event.issue.labels.*.name, 'Monthly Roundup')
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Create next month's roundup issue
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const months = [
+              'January', 'February', 'March', 'April', 'May', 'June',
+              'July', 'August', 'September', 'October', 'November', 'December'
+            ];
+
+            const now = new Date();
+            const nextMonth = new Date(now.getFullYear(), now.getMonth() + 1, 1);
+            const monthName = months[nextMonth.getMonth()];
+            const year = nextMonth.getFullYear();
+            const title = `What's new for developers? (${monthName} ${year})`;
+
+            // Check if an issue for next month already exists
+            const existing = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              labels: 'Monthly Roundup',
+              per_page: 10
+            });
+
+            if (existing.data.some(issue => issue.title === title)) {
+              console.log(`Issue "${title}" already exists, skipping`);
+              return;
+            }
+
+            const body = [
+              'This is a rolling discussion for a monthly series that is intended to keep track of the items, PRs, Trac tickets, and Make blog posts that are interesting/important for developers. The goal is to publish a post on the 10th of each month with the previous month\'s updates.',
+              '',
+              'Everyone is welcome to contribute to this monthly document. If you find something interesting, just create a new reply to this discussion below.',
+              '',
+              '**Google Doc:** _to be added_',
+              '',
+              '**Author:** _to be assigned_'
+            ].join('\n');
+
+            const issue = await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: title,
+              body: body,
+              labels: ['Monthly Roundup']
+            });
+
+            console.log(`✅ Created issue #${issue.data.number}: ${title}`);


### PR DESCRIPTION
## Summary
- When a "Monthly Roundup" issue is closed, automatically creates the next month's issue
- Applies the "Monthly Roundup" label, which triggers the existing label-notifier workflow
- Includes a dedup check to avoid creating a duplicate if one already exists
- Google Doc link and author are left as placeholders to be filled in manually
- Posts a comment pinging @justintadlock and @bph to update the Google Doc and assign an author

## Rules
The workflow only triggers when **all** of these conditions are met:
- The closed issue has the **Monthly Roundup** label
- A **human** (not a bot) closed the issue
- The issue was closed as **completed** (not "not planned")

## How it works
1. Human closes a "Monthly Roundup" issue as completed
2. Workflow calculates next month/year from the current date
3. Creates a new issue titled "What's new for developers? (Month Year)"
4. Applies the label → triggers the existing notifier → pings the team
5. Posts a follow-up comment notifying @justintadlock and @bph to update the Google Doc and assign an author

## Test plan
- [x] Close a Monthly Roundup issue and verify the next one is created
- [x] Verify the label is applied and the notifier fires
- [x] Verify the editor notification comment is posted
- [x] Verify dedup: closing again doesn't create a duplicate
- [x] Verify "not planned" closures do not trigger the workflow