### PR TITLE
Fix follow-up dedup: match original message, not the other way around

### DIFF
--- a/.github/workflows/label-notifier.yml
+++ b/.github/workflows/label-notifier.yml
@@ -73,7 +73,7 @@ jobs:
             });
             
             const hasFollowup = comments.data.some(comment => 
-              comment.body.includes('📢 20-Day Follow-up Reminder')
+              comment.body.includes('📢 Reminder')
             );
             
             if (hasFollowup) {
@@ -82,7 +82,7 @@ jobs:
             }
             
             // Send the follow-up notification
-            const message = `📢 20-Day Follow-up Reminder ${recipients} The publication deadline is approaching (5th of the month).`;
+            const message = `📢 Reminder ${recipients} The publication deadline is approaching (5th of the month).`;
             
             await github.rest.issues.createComment({
               owner: context.repo.owner,


### PR DESCRIPTION
## Summary
- PR #461 fixed the dedup mismatch by changing the message to match the check
- This reverses that: changes the check to match the original message (`📢 Reminder`)
- Shorter, simpler, and restores the original message wording

## Changes
- Dedup check: `📢 20-Day Follow-up Reminder` → `📢 Reminder`
- Message: `📢 20-Day Follow-up Reminder ...` → `📢 Reminder ...` (back to original)