### PR TITLE
Post heads-up notification when auto-creating monthly roundup issue

### DIFF
--- a/.github/workflows/create-roundup-issue.yml
+++ b/.github/workflows/create-roundup-issue.yml
@@ -4,6 +4,9 @@ on:
   issues:
     types: [closed]
 
+env:
+  RECIPIENTS: '@bph @adamziel @jonathanbossenger @alexapeduzzi @fellyph'
+
 jobs:
   create-next-issue:
     if: >-
@@ -72,4 +75,16 @@ jobs:
               repo: context.repo.repo,
               issue_number: issue.data.number,
               body: '@justintadlock @bph Please update the **Google Doc** link and assign an **Author** for this edition.'
+            });
+
+            // Heads-up notification to contributors.
+            // Posted here because the 'labeled' event from this bot-created
+            // issue does not trigger label-notifier.yml (GitHub Actions does
+            // not chain workflows triggered by GITHUB_TOKEN).
+            const recipients = process.env.RECIPIENTS;
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issue.data.number,
+              body: `Heads-up ${recipients}: To include your project's **news for developers**, please add the information or a link as a comment to this issue.\n**Deadline 5th of next month.**`
             });

--- a/.github/workflows/label-notifier.yml
+++ b/.github/workflows/label-notifier.yml
@@ -9,7 +9,14 @@ env:
   RECIPIENTS: '@bph @adamziel @jonathanbossenger @alexapeduzzi @fellyph'
 
 jobs:
-  # Initial notification when label is applied
+  # Initial notification when the Monthly Roundup label is applied manually.
+  #
+  # NOTE: For the normal monthly cycle, the heads-up comment is posted directly
+  # by create-roundup-issue.yml when it auto-creates the next issue. GitHub
+  # Actions does not chain workflows triggered by GITHUB_TOKEN, so the
+  # 'labeled' event from the bot-created issue does not reach this job.
+  # This job exists as a fallback for off-cycle / manually-created roundup
+  # issues. Keep the message text in sync with create-roundup-issue.yml.
   initial-notification:
     if: github.event_name == 'issues' && contains(github.event.issue.labels.*.name, 'Monthly Roundup')
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Fixes the missing heads-up notification on auto-created Monthly Roundup issues (e.g. #471).

## Root cause

`label-notifier.yml`'s `initial-notification` job listens for the `labeled` event on issues. However, **GitHub Actions does not chain workflows triggered by `GITHUB_TOKEN`** — so when `create-roundup-issue.yml` auto-creates the next month's issue with the `Monthly Roundup` label, the resulting `labeled` event is suppressed and `label-notifier.yml` never runs. The notification only fires when a human manually applies the label, which is why this wasn't caught earlier.

## Fix

Post the heads-up comment directly inside `create-roundup-issue.yml`, right after the existing "update Google Doc / assign Author" comment. This bypasses the workflow-chaining limitation entirely and keeps `label-notifier.yml` working for the manual-label path.

The recipient list is hoisted into a workflow-level \`env:\` to make it easy to keep in sync with \`label-notifier.yml\`.

## Test plan

- [ ] After merge, close the current Monthly Roundup issue (#471) once the May edition is published and verify the new issue receives both comments automatically.
- [ ] Manually applying the \`Monthly Roundup\` label to a test issue still triggers \`label-notifier.yml\` (no regression).